### PR TITLE
Display the flag list in a table

### DIFF
--- a/_pages/documentation/user/flags/list.html.twig
+++ b/_pages/documentation/user/flags/list.html.twig
@@ -7,54 +7,63 @@ parent:
 ---
 
 {% extends "_layouts/page.html.twig" %}
+{% from _self import flag_list %}
+
+{% macro flag_list(flags) -%}
+    <table>
+        <thead>
+        <tr>
+            <th>
+                <abbr title="Abbreviation">Abbr</abbr>
+            </th>
+            <th>Name</th>
+            <th>Description</th>
+        </tr>
+        </thead>
+
+        <tbody>
+            {% for flag in flags | order('filename') %}
+                <tr>
+                    <td class="text-center">
+                        {{- flag.abbreviation -}}
+                    </td>
+                    <td>
+                        <a href="{{ url(flag) }}"
+                           class="text-decoration-none"
+                        >
+                            {{- flag.name -}}
+                        </a>
+                    </td>
+                    <td>
+                        {{ flag.summary -}}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{%- endmacro %}
 
 {% set flags = collections.flags | group('type') %}
 {% set types = ['Good', 'Bad'] %}
 
 {% block content %}
-    <h1>Flags</h1>
-    <p>There are two types of flags in BZFlag: team flags and super flags. Team flags only show up in the Capture The Flag game mode.</p>
-    <p>Super flags come in both a good and bad variety. Servers can choose to include specific flags, and many do not include any bad flags at all. Some servers may not have any flags.</p>
+    {% markdown %}
+        # Flags
 
-    {% for type in types %}
-        <h2 id="{{ type | slug }}-flags">{{ type }} Flags</h2>
+        There are two types of flags in BZFlag: team flags and super flags. Team flags only show up in the Capture The Flag game mode.
 
-        {% if type == 'Good' %}
-            <p>Good super flags provide some additional benefit, such as faster movement, a smaller tank, or different weapons like laser or guided missile.</p>
-        {% elseif type == 'Bad' %}
-            <p>Bad super flags disable parts of the tank or reduce performance of the tank.</p>
-        {% endif %}
+        Super flags come in both a good and bad variety. Servers can choose to include specific flags, and many do not include any bad flags at all. Some servers may not have any flags.
 
-        <table>
-            <thead>
-                <tr>
-                    <th>
-                        <abbr title="Abbreviation">Abbr</abbr>
-                    </th>
-                    <th>Name</th>
-                    <th>Description</th>
-                </tr>
-            </thead>
+        ## Good Flags
 
-            <tbody>
-                {% for flag in flags[type] | order('filename') %}
-                    <tr>
-                        <td class="text-center">
-                            {{- flag.abbreviation -}}
-                        </td>
-                        <td>
-                            <a href="{{ url(flag) }}"
-                               class="text-decoration-none"
-                            >
-                                {{- flag.name -}}
-                            </a>
-                        </td>
-                        <td>
-                            {{ flag.summary -}}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% endfor %}
+        Good super flags provide some additional benefit, such as faster movement, a smaller tank, or different weapons like laser or guided missile.
+
+        {{ flag_list(flags.Good) }}
+
+        ## Bad Flags
+
+        Bad super flags disable parts of the tank or reduce performance of the tank.
+
+        {{ flag_list(flags.Bad) }}
+    {% endmarkdown %}
 {% endblock %}

--- a/_pages/documentation/user/flags/list.html.twig
+++ b/_pages/documentation/user/flags/list.html.twig
@@ -17,22 +17,44 @@ parent:
     <p>Super flags come in both a good and bad variety. Servers can choose to include specific flags, and many do not include any bad flags at all. Some servers may not have any flags.</p>
 
     {% for type in types %}
-        <h2>{{ type }} Flags</h2>
+        <h2 id="{{ type | slug }}-flags">{{ type }} Flags</h2>
+
         {% if type == 'Good' %}
-        <p>Good super flags provide some additional benefit, such as faster movement, a smaller tank, or different weapons like laser or guided missile.</p>
+            <p>Good super flags provide some additional benefit, such as faster movement, a smaller tank, or different weapons like laser or guided missile.</p>
         {% elseif type == 'Bad' %}
-        <p>Bad super flags disable parts of the tank or reduce performance of the tank.</p>
+            <p>Bad super flags disable parts of the tank or reduce performance of the tank.</p>
         {% endif %}
-        <ul>
-            {% for flag in flags[type] | order('filename') %}
-                <li>
-                    <a href="{{ url(flag) }}"
-                       class="text-decoration-none"
-                    >
-                        {{- flag.name -}}
-                    </a> - {{ flag.summary -}}
-                </li>
-            {% endfor %}
-        </ul>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>
+                        <abbr title="Abbreviation">Abbr</abbr>
+                    </th>
+                    <th>Name</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                {% for flag in flags[type] | order('filename') %}
+                    <tr>
+                        <td class="text-center">
+                            {{- flag.abbreviation -}}
+                        </td>
+                        <td>
+                            <a href="{{ url(flag) }}"
+                               class="text-decoration-none"
+                            >
+                                {{- flag.name -}}
+                            </a>
+                        </td>
+                        <td>
+                            {{ flag.summary -}}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     {% endfor %}
 {% endblock %}

--- a/_pages/documentation/user/flags/list.html.twig
+++ b/_pages/documentation/user/flags/list.html.twig
@@ -10,31 +10,34 @@ parent:
 {% from _self import flag_list %}
 
 {% macro flag_list(flags) -%}
-    <table>
+    {%- set col_1 = "col-3 col-md-2 col-lg-auto text-center" -%}
+    {%- set col_2 = "col-9 col-md-10 col-lg-auto border-r-none border-lg-r" -%}
+
+    <table class="responsive-lg">
         <thead>
-        <tr>
-            <th>
-                <abbr title="Abbreviation">Abbr</abbr>
-            </th>
-            <th>Name</th>
-            <th>Description</th>
-        </tr>
+            <tr>
+                <th class="{{ col_1 }}">
+                    <abbr title="Abbreviation">Abbr</abbr>
+                </th>
+                <th class="{{ col_2 }}">Name</th>
+                <th class="hide-xs show-lg">Description</th>
+            </tr>
         </thead>
 
         <tbody>
             {% for flag in flags | order('filename') %}
                 <tr>
-                    <td class="text-center">
+                    <td class="{{ col_1 }}">
                         {{- flag.abbreviation -}}
                     </td>
-                    <td>
+                    <td class="{{ col_2 }}">
                         <a href="{{ url(flag) }}"
-                           class="text-decoration-none"
+                           class="text-decoration-none text-nowrap"
                         >
                             {{- flag.name -}}
                         </a>
                     </td>
-                    <td>
+                    <td class="border-t border-lg-t-none col-12">
                         {{ flag.summary -}}
                     </td>
                 </tr>

--- a/_sass/components/_table.scss
+++ b/_sass/components/_table.scss
@@ -4,10 +4,6 @@ table {
     border-collapse: collapse;
     width: 100%;
 
-    @include respond-up(lg) {
-        width: 90%;
-    }
-
     thead tr {
         background-color: rgba(#000, 0.2);
     }
@@ -15,11 +11,7 @@ table {
     td, th {
         @include padding(null, 3);
 
-        border: $border-default;
-
-        &:first-child {
-            border-left-color: transparent;
-        }
+        border-right: $border-default;
 
         &:last-child {
             border-right-color: transparent;
@@ -31,12 +23,26 @@ table {
     }
 
     tr {
+        border-top: $border-default;
+
         &:last-child td {
             border-bottom-color: transparent;
         }
 
         &:nth-child(even) {
             background-color: rgba(#fff, 0.05);
+        }
+    }
+}
+
+@each $breakpoint in map-keys($breakpoints) {
+    @include respond-down($breakpoint) {
+        table.responsive-#{$breakpoint} {
+            tr {
+                display: flex;
+                flex-wrap: wrap;
+                width: 100%;
+            }
         }
     }
 }


### PR DESCRIPTION
Let's display the flags in a bit more visually appealing manner and make the flag abbreviations listed on this page. This change will show the flags in a three column table on large screens and on smaller screens, it'll will appear as a two column table with the last column wrapped in a new row of the same background color.

![Sizzy-iPhone 11 Pro 0 0 0 0 30Dec 20 51](https://user-images.githubusercontent.com/1246453/71610478-3b405b80-2b46-11ea-8257-dd80d4ef2094.png)
![Sizzy-iPad Pro 10 5 0 0 0 0 30Dec 20 51](https://user-images.githubusercontent.com/1246453/71610477-3b405b80-2b46-11ea-806f-ce954ce4fe00.png)
![Sizzy-MacBook Air 0 0 0 0 30Dec 20 51](https://user-images.githubusercontent.com/1246453/71610479-3b405b80-2b46-11ea-93bb-66596d48d7a5.png)