### PR TITLE
Add documentation for `bz_getSpawnPointWithin` and `bz_isWithinWorldBoundaries`

### DIFF
--- a/_documentation/developer/bzfs_api_functions/bz_getSpawnPointWithin.md
+++ b/_documentation/developer/bzfs_api_functions/bz_getSpawnPointWithin.md
@@ -1,0 +1,28 @@
+---
+since: 2.4.20
+category: Spawn Management
+signatures:
+    - - dataType: bz_CustomZoneObject*
+        name: obj
+        description: The `bz_CustomZoneObject` that will be used as a bounding box to determine a spawn point.
+        default: ~
+      - dataType: float
+        name: randomPos[3]
+        description: The pointer to the random spawn position (X, Y, and Z) within `obj`.
+        default: ~
+returns:
+    dataType: bool
+    description: True when a spawn point was able to be found within the given parameters.
+---
+
+Get a random position within a `bz_CustomZoneObject` that is safe for a player to spawn at.
+
+The following considerations are taken into account when this function determines a "spawn point":
+
+- The point is within the world boundaries (max height too)
+- The point does not collide with map objects
+- The point has enough vertical clearance for a tank to spawn at
+
+If a "spawn point" could not be determined within the given zone, this function will return `false`. If this function returns `false`, you **cannot** trust the points set to `randomPos`; they will simply be the last random position that was tested before this function gave up.
+
+This function respects the `_spawnMaxCompTime` BZDB setting when trying to calculate a random spawn position.

--- a/_documentation/developer/bzfs_api_functions/bz_getStandardSpawn.md
+++ b/_documentation/developer/bzfs_api_functions/bz_getStandardSpawn.md
@@ -1,22 +1,22 @@
 ---
 since: 2.4.0
-category: Server Management
+category: Spawn Management
 signatures:
     - - dataType: int
         name: playerID
-        description: ~
+        description: The player ID for whom to get a spawn position for
         default: ~
       - dataType: float
         name: pos[3]
-        description: ~
+        description: The spawn position a player will be able to spawn at.
         default: ~
       - dataType: float*
         name: rot
-        description: ~
+        description: The rotation a player will have for this spawn.
         default: ~
 returns:
     dataType: bool
     description: ~
 ---
 
-This function needs a description. Please feel free to contribute a description to this function.
+Get a standard spawn position for a player anywhere on the map.

--- a/_documentation/developer/bzfs_api_functions/bz_isWithinWorldBoundaries.md
+++ b/_documentation/developer/bzfs_api_functions/bz_isWithinWorldBoundaries.md
@@ -1,0 +1,14 @@
+---
+since: 2.4.20
+category: Spawn Management
+signatures:
+    - - dataType: float
+        name: pos[3]
+        description: The pointer to the position (X, Y, and Z) to check.
+        default: ~
+returns:
+    dataType: bool
+    description: True when the given position is within the world boundaries.
+---
+
+Check to see whether a specific point is inside the world's boundaries.


### PR DESCRIPTION
Let's add documentation for our new `bz_getSpawnPointWithin` function introduced in https://github.com/BZFlag-Dev/bzflag/pull/229.

This PR also documents `bz_getStandardSpawn` since I was touching the new "Spawn Management" category of the API function docs.

**Blocked by:** https://github.com/BZFlag-Dev/bzflag/pull/242