### PR TITLE
Small fixes to slash commands page

### DIFF
--- a/_pages/documentation/user/slash-commands/list.html.twig
+++ b/_pages/documentation/user/slash-commands/list.html.twig
@@ -14,7 +14,7 @@ parent:
 {% set categories = [
     {
         title: 'Player',
-        desc: 'There commands are generally available to normal players, though some servers may restrict some of them to registered players.',
+        desc: 'These commands are generally available to normal players, though some servers may restrict some of them to registered players.',
     },
     {
         title: 'Admin',

--- a/_pages/documentation/user/slash-commands/list.html.twig
+++ b/_pages/documentation/user/slash-commands/list.html.twig
@@ -49,7 +49,7 @@ parent:
         <p>{{ category.desc }}</p>
 
         <ul>
-            {% for command in commands[category.title] %}
+            {% for command in commands[category.title] | order('filename') %}
                 <li>
                     <a href="{{ url(command) }}">
                         /{{ command.command }}

--- a/_pages/documentation/user/slash-commands/show.html.twig
+++ b/_pages/documentation/user/slash-commands/show.html.twig
@@ -49,7 +49,7 @@ parent:
         data-target="#sidebar-toc"
         data-breakpoint="lg"
     >
-        Other Commands
+        {{ this.category }} Commands
     </h2>
 
     <div id="sidebar-toc" class="c-accordion__body">


### PR DESCRIPTION
I noticed that in the sub pages of slash commands they were sorted alphabetically, so I thought why not on the overview page as well.
Changed the wording in the sidebar of the categories because I thought it would be more clear showing that it's the list of commands for that category.
Found a typo.