### PR TITLE
Add documentation of basic client commands

### DIFF
--- a/_documentation/user/slash_commands/bind.md
+++ b/_documentation/user/slash_commands/bind.md
@@ -1,0 +1,14 @@
+---
+command: bind
+syntax: "<event> <press> <action>"
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Bind `<event>` to an `<action>`.
+
+`<event>` can be any key, button, or combination strung together, such as `"Shift+Page Up"` double quotes are only necessary if there are spaces.  
+`<press>` can be `up`, `down`, or `both`.  
+`<action>` is the command to be triggered.
+

--- a/_documentation/user/slash_commands/cmds.md
+++ b/_documentation/user/slash_commands/cmds.md
@@ -1,0 +1,9 @@
+---
+command: "cmds"
+syntax: ~
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Show a list of all client and server commands.

--- a/_documentation/user/slash_commands/debug.md
+++ b/_documentation/user/slash_commands/debug.md
@@ -1,0 +1,9 @@
+---
+command: "debug"
+syntax: "[level]"
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Show or set the client debug level to `[level]`

--- a/_documentation/user/slash_commands/diff.md
+++ b/_documentation/user/slash_commands/diff.md
@@ -1,0 +1,9 @@
+---
+command: "diff"
+syntax: ~
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+List all BZDB server variables that are not set to the default value

--- a/_documentation/user/slash_commands/dumpvars.md
+++ b/_documentation/user/slash_commands/dumpvars.md
@@ -1,0 +1,9 @@
+---
+command: "dumpvars"
+syntax: ~
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Dump a list of all set variables and their values to the standard output

--- a/_documentation/user/slash_commands/forceradar.md
+++ b/_documentation/user/slash_commands/forceradar.md
@@ -1,0 +1,9 @@
+---
+command: forceradar
+syntax: ~
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Force the radar to be displayed (only works for observers)

--- a/_documentation/user/slash_commands/highlight.md
+++ b/_documentation/user/slash_commands/highlight.md
@@ -2,7 +2,7 @@
 command: highlight
 syntax: "[pattern]"
 since: 2.4.0
-category: Player
+category: Client
 permissions: ~
 ---
 

--- a/_documentation/user/slash_commands/localset.md
+++ b/_documentation/user/slash_commands/localset.md
@@ -1,0 +1,8 @@
+---
+command: bind
+syntax: "<key> <press> <action>"
+since: 2.4.0
+category: Client
+---
+
+

--- a/_documentation/user/slash_commands/localset.md
+++ b/_documentation/user/slash_commands/localset.md
@@ -1,8 +1,34 @@
 ---
-command: bind
-syntax: "<key> <press> <action>"
+command: localset
+syntax: "variable [value]"
 since: 2.4.0
 category: Client
+permissions: ~
 ---
 
+Read a local variable or set it to `[value]`
 
+## Examples:
+```
+/localset highlightPattern "laser"
+/localset highlightPattern "laser|genocide"
+/localset highlightPattern "(Team Flag|Team's Flag|Genocide)"
+```
+*highlightPattern* highlights lines with the selected words when they appear in the console(chat box).
+- When highlighting one word, just type the word in quotes, such as "laser."
+- If one wants to highlight two or more words, the words must be separated with a '|', such as "laser|genocide" (highlights lines with laser OR genocide).
+- If any of the words have spaces, all the words must be surrounded in parentheses, such as "(Team Flag|Team's Flag|Genocide)" (highlights lines with "Team Flag," "Team's Flag," OR "Genocide").
+
+&nbsp;
+```
+/localset linedradarshots 60
+```
+*linedradarshots* sets how long shots are on the radar. While this option is set-able through the in-game GUI, you can only set this setting up to 10 via the GUI. You can hand-edit your config to give you longer shot lengths.
+
+&nbsp;
+```
+/localset latitude 38
+/localset longitude -77
+```
+*latitude* and *longitude* set the latitude and longitude for BZFlag's sky rendering system.  
+*Hint: To always have a black sky set latitude 90 (north pole) or -90 (south pole) for winter/summer respectively.*

--- a/_documentation/user/slash_commands/quit.md
+++ b/_documentation/user/slash_commands/quit.md
@@ -2,7 +2,7 @@
 command: quit
 syntax: "[message]"
 since: 2.4.0
-category: Player
+category: Client
 permissions: ~
 ---
 

--- a/_documentation/user/slash_commands/retexture.md
+++ b/_documentation/user/slash_commands/retexture.md
@@ -1,0 +1,9 @@
+---
+command: "retexture"
+syntax: ~
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Reload the textures of the game

--- a/_documentation/user/slash_commands/roampos.md
+++ b/_documentation/user/slash_commands/roampos.md
@@ -1,0 +1,9 @@
+---
+command: "roampos"
+syntax: "{reset|send|angle|x y z [theta [phi [zoom]]]}"
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Manipulate the observer camera (only useful in Roaming and Tracking modes). Without arguments, it shows a usage message and the current camera location. `reset` resets  the  camera's location to the center of the map and `send` sends information about the camera to the server. `angle` moves the camera outside the map at a certain angle, looking towards its center. `x`, `y` and `z` are used to set the camera's location, theta defines the camera's horizontal angle, `phi` defines its vertical angle and `zoom` sets the camera's zoom level. All angles are defined in degrees.

--- a/_documentation/user/slash_commands/savemsgs.md
+++ b/_documentation/user/slash_commands/savemsgs.md
@@ -1,0 +1,9 @@
+---
+command: "savemsgs"
+syntax: "[-s] [-t]"
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Save all messages to a file in your config directory. If `-s` is provided, coloring data are stripped.  If `-t` is provided, timestamps are added to the messages.

--- a/_documentation/user/slash_commands/saveworld.md
+++ b/_documentation/user/slash_commands/saveworld.md
@@ -1,0 +1,9 @@
+---
+command: "saveworld"
+syntax: "[-g] [-m] [-o] filename"
+since: 2.4.0
+category: Client
+permissions: ~
+---
+
+Save the current world to filename. Specify `-g` to prevent the creation of groups, `-m` to save some primitives as meshes and `-o` to create a WaveFront OBJ file instead of a BZW one.

--- a/_documentation/user/slash_commands/silence.md
+++ b/_documentation/user/slash_commands/silence.md
@@ -2,7 +2,7 @@
 command: silence
 syntax: "<callsign>"
 since: 2.4.0
-category: Player
+category: Client
 permissions: ~
 ---
 

--- a/_documentation/user/slash_commands/unsilence.md
+++ b/_documentation/user/slash_commands/unsilence.md
@@ -2,7 +2,7 @@
 command: unsilence
 syntax: "<callsign>"
 since: 2.4.0
-category: Player
+category: Client
 permissions: ~
 ---
 

--- a/_pages/documentation/user/slash-commands/list.html.twig
+++ b/_pages/documentation/user/slash-commands/list.html.twig
@@ -14,7 +14,7 @@ parent:
 {% set categories = [
     {
         title: 'Client',
-        desc: 'These commands are for the local BZFlag client, they can be used to change settings.',
+        desc: 'These are the base commands of the BZFlag client.',
     },
     {
         title: 'Player',

--- a/_pages/documentation/user/slash-commands/list.html.twig
+++ b/_pages/documentation/user/slash-commands/list.html.twig
@@ -13,6 +13,10 @@ parent:
 {% set commands = collections.slash_commands | group('category') %}
 {% set categories = [
     {
+        title: 'Client',
+        desc: 'These commands are for the local BZFlag client, they can be used to change settings.',
+    },
+    {
         title: 'Player',
         desc: 'There commands are generally available to normal players, though some servers may restrict some of them to registered players.',
     },


### PR DESCRIPTION
Creates documentation for the client side only commands, bringing descriptions from the bzflag man pages and old wiki.